### PR TITLE
Make non-alpha/VQE/QAOA grove modules pyQuil2.0 compatible

### DIFF
--- a/examples/GroversAlgorithm.ipynb
+++ b/examples/GroversAlgorithm.ipynb
@@ -14,9 +14,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from pyquil.api import QVMConnection\n",
     "from itertools import product\n",
+    "\n",
     "from mock import patch, Mock\n",
+    "from pyquil.api import QuantumComputer\n",
     "\n",
     "from grove.amplification.grover import Grover"
    ]
@@ -75,7 +76,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "To use Grover's algorithm on quantum hardware we need to define a connection to a QVM or QPU. However we don't have a real connection in this notebook, so we just mock out the response. If you intend to run this notebook on a QVM or QPU, ensure to replace `cxn` with a pyQuil connection object."
+    "To use Grover's algorithm on quantum hardware we need to define a connection to a QVM or QPU. However we don't have a real connection in this notebook, so we just mock out the response. If you intend to run this notebook on a QVM or QPU,  be sure to replace `qc` with a pyQuil QuantumComputer object."
    ]
   },
   {
@@ -84,8 +85,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "with patch(\"pyquil.api.QVMConnection\") as cxn:\n",
-    "    cxn.run_and_measure.return_value = [[int(bit) for bit in target_bitstring]]"
+    "with patch(\"pyquil.api.QuantumComputer\") as qc:\n",
+    "    qc.run.return_value = [[int(bit) for bit in target_bitstring]]"
    ]
   },
   {
@@ -103,8 +104,8 @@
    "outputs": [],
    "source": [
     "grover = Grover()\n",
-    "found_bitstring = grover.find_bitstring(cxn, bitstring_map)\n",
-    "assert \"\".join(found_bitstring) == target_bitstring, \"Found bitstring is not the expected bitstring\""
+    "found_bitstring = grover.find_bitstring(qc, bitstring_map)\n",
+    "assert found_bitstring == target_bitstring, \"Found bitstring is not the expected bitstring\""
    ]
   },
   {

--- a/examples/SimonsAlgorithm.ipynb
+++ b/examples/SimonsAlgorithm.ipynb
@@ -17,9 +17,10 @@
    "outputs": [],
    "source": [
     "from collections import defaultdict\n",
-    "from pyquil.api import SyncConnection\n",
+    "\n",
     "import numpy as np\n",
     "from mock import patch\n",
+    "from pyquil.api import QuantumComputer\n",
     "\n",
     "from grove.simon.simon import Simon, create_valid_2to1_bitmap"
    ]
@@ -96,9 +97,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "with patch(\"pyquil.api.SyncConnection\") as cxn:\n",
+    "with patch(\"pyquil.api.QuantumComputer\") as qc:\n",
     "    # Need to mock multiple returns as an iterable\n",
-    "    cxn.run_and_measure.side_effect = [\n",
+    "    qc.run.side_effect = [\n",
     "        (np.asarray([0, 1, 1], dtype=int), ),\n",
     "        (np.asarray([1, 1, 1], dtype=int), ),\n",
     "        (np.asarray([1, 1, 1], dtype=int), ),\n",
@@ -121,7 +122,7 @@
    "outputs": [],
    "source": [
     "sa = Simon()\n",
-    "found_mask = sa.find_mask(cxn, bm)\n",
+    "found_mask = sa.find_mask(qc, bm)\n",
     "assert ''.join([str(b) for b in found_mask]) == mask, \"Found mask is not expected mask\""
    ]
   },

--- a/grove/amplification/amplification.py
+++ b/grove/amplification/amplification.py
@@ -14,13 +14,16 @@
 #    limitations under the License.
 ##############################################################################
 
-"""Module for amplitude amplification, for use in algorithms such as Grover's algorithm.
+"""
+Module for amplitude amplification, for use in algorithms such as Grover's algorithm.
 
  See G. Brassard, P. Hoyer, M. Mosca (2000) `Quantum Amplitude Amplification and Estimation
  <https://arxiv.org/abs/quant-ph/0005055>`_ for more information.
 """
+from typing import List
+
 import numpy as np
-import pyquil.quil as pq
+from pyquil import Program
 from pyquil.gates import H, X, Z, RZ, STANDARD_GATES
 
 from grove.utils.utility_programs import ControlledProgramBuilder
@@ -31,8 +34,8 @@ X_GATE_LABEL = "NOT"
 HADAMARD_DIFFUSION_LABEL = "HADAMARD_DIFFUSION"
 
 
-def diffusion_program(qubits):
-    diffusion_program = pq.Program()
+def diffusion_program(qubits: List[int]) -> Program:
+    diffusion_program = Program()
     dim = 2 ** len(qubits)
     hadamard_diffusion_matrix = np.diag([1.0] + [-1.0] * (dim - 1))
     diffusion_program.defgate(HADAMARD_DIFFUSION_LABEL, hadamard_diffusion_matrix)
@@ -41,25 +44,27 @@ def diffusion_program(qubits):
     return diffusion_program
 
 
-def amplification_circuit(algorithm, oracle, qubits, num_iter, decompose_diffusion=False):
+def amplification_circuit(algorithm: Program, oracle: Program,
+                          qubits: List[int],
+                          num_iter: int,
+                          decompose_diffusion: bool = False) -> Program:
     """
     Returns a program that does ``num_iter`` rounds of amplification, given a measurement-less
     algorithm, an oracle, and a list of qubits to operate on.
 
-    :param Program algorithm: A program representing a measurement-less algorithm run on qubits.
-    :param Program oracle: An oracle maps any basis vector ``|psi>`` to either ``+|psi>`` or
+    :param algorithm: A program representing a measurement-less algorithm run on qubits.
+    :param oracle: An oracle maps any basis vector ``|psi>`` to either ``+|psi>`` or
         ``-|psi>`` depending on whether ``|psi>`` is in the desirable subspace or the undesirable
         subspace.
-    :param Sequence qubits: the qubits to operate on
-    :param int num_iter: number of iterations of amplifications to run
-    :param bool decompose_diffusion: If True, decompose the Grover diffusion gate into two qubit
+    :param qubits: the qubits to operate on
+    :param num_iter: number of iterations of amplifications to run
+    :param decompose_diffusion: If True, decompose the Grover diffusion gate into two qubit
      gates. If False, use a defgate to define the gate.
     :return: The amplified algorithm.
-    :rtype: Program
     """
-    program = pq.Program()
+    program = Program()
 
-    uniform_superimposer = pq.Program().inst([H(qubit) for qubit in qubits])
+    uniform_superimposer = Program().inst([H(qubit) for qubit in qubits])
     program += uniform_superimposer
     if decompose_diffusion:
         diffusion = decomposed_diffusion_program(qubits)
@@ -78,7 +83,7 @@ def amplification_circuit(algorithm, oracle, qubits, num_iter, decompose_diffusi
     return program
 
 
-def decomposed_diffusion_program(qubits):
+def decomposed_diffusion_program(qubits: List[int]) -> Program:
     """
     Constructs the diffusion operator used in Grover's Algorithm, acted on both sides by an
     a Hadamard gate on each qubit. Note that this means that the matrix representation of this
@@ -95,7 +100,7 @@ def decomposed_diffusion_program(qubits):
                    The operator operates on bistrings of the form
                    ``|qubits[0], ..., qubits[-1]>``.
     """
-    program = pq.Program()
+    program = Program()
     if len(qubits) == 1:
         program.inst(Z(qubits[0]))
     else:

--- a/grove/amplification/grover.py
+++ b/grove/amplification/grover.py
@@ -102,8 +102,7 @@ class Grover(object):
 
         ro = self.grover_circuit.declare('ro', 'BIT', len(self.qubits))
         self.grover_circuit += [MEASURE(qubit, ro[idx]) for idx, qubit in enumerate(self.qubits)]
-        self.grover_circuit.wrap_in_numshots_loop(1)
-        executable = qc.compiler.native_quil_to_executable(self.grover_circuit)
+        executable = qc.compile(self.grover_circuit)
         sampled_bitstring = qc.run(executable)
 
         return "".join([str(bit) for bit in sampled_bitstring[0]])

--- a/grove/amplification/grover.py
+++ b/grove/amplification/grover.py
@@ -13,12 +13,15 @@
 #    See the License for the specific language governing permissions and
 #    limitations under the License.
 ##############################################################################
-"""Module for Grover's algorithm.
 """
+Module for Grover's algorithm.
+"""
+from typing import Dict, List
 
 import numpy as np
-import pyquil.quil as pq
-from pyquil.gates import H
+from pyquil import Program
+from pyquil.api import QuantumComputer
+from pyquil.gates import H, MEASURE
 
 from grove.amplification.amplification import amplification_circuit
 
@@ -37,15 +40,14 @@ class Grover(object):
         self.bit_map = None
 
     @staticmethod
-    def _compute_grover_oracle_matrix(bitstring_map):
-        """Computes the unitary matrix that encodes the oracle function for Grover's algorithm
+    def _compute_grover_oracle_matrix(bitstring_map: Dict[str, int]) -> np.ndarray:
+        """
+        Computes the unitary matrix that encodes the oracle function for Grover's algorithm
 
         :param bitstring_map: dict with string keys corresponding to bitstrings,
          and integer values corresponding to the desired phase on the output state.
-        :type bitstring_map: Dict[String, Int]
         :return: a numpy array corresponding to the unitary matrix for oracle for the given
          bitstring_map
-        :rtype: numpy.ndarray
         """
         n_bits = len(list(bitstring_map.keys())[0])
         oracle_matrix = np.zeros(shape=(2 ** n_bits, 2 ** n_bits))
@@ -55,26 +57,26 @@ class Grover(object):
             oracle_matrix[b, b] = phase_factor
         return oracle_matrix
 
-    def _construct_grover_circuit(self):
-        """Contructs an instance of Grover's Algorithm, using initialized values.
+    def _construct_grover_circuit(self) -> None:
+        """
+        Constructs an instance of Grover's Algorithm, using initialized values.
 
         :return: None
-        :rtype: NoneType
         """
-        oracle = pq.Program()
+        oracle = Program()
         oracle_name = "GROVER_ORACLE"
         oracle.defgate(oracle_name, self.unitary_function_mapping)
         oracle.inst(tuple([oracle_name] + self.qubits))
         self.grover_circuit = self.oracle_grover(oracle, self.qubits)
 
-    def _init_attr(self, bitstring_map):
-        """Initializes an instance of Grover's Algorithm given a bitstring_map.
+    def _init_attr(self, bitstring_map: Dict[str, int]) -> None:
+        """
+        Initializes an instance of Grover's Algorithm given a bitstring_map.
 
         :param bitstring_map: dict with string keys corresponding to bitstrings, and integer
          values corresponding to the desired phase on the output state.
         :type bitstring_map: Dict[String, Int]
         :return: None
-        :rtype: NoneType
         """
         self.bit_map = bitstring_map
         self.unitary_function_mapping = self._compute_grover_oracle_matrix(bitstring_map)
@@ -82,42 +84,45 @@ class Grover(object):
         self.qubits = list(range(int(np.log2(self.n_qubits))))
         self._construct_grover_circuit()
 
-    def find_bitstring(self, cxn, bitstring_map):
+    def find_bitstring(self, qc: QuantumComputer, bitstring_map: Dict[str, int]) -> str:
         """
         Runs Grover's Algorithm to find the bitstring that is designated by ``bistring_map``.
 
         In particular, this will prepare an initial state in the uniform superposition over all bit-
         strings, an then use Grover's Algorithm to pick out the desired bitstring.
 
-        :param QVMConnection cxn: the connection to the Rigetti cloud to run pyQuil programs.
+        :param qc: the connection to the Rigetti cloud to run pyQuil programs.
         :param bitstring_map: a mapping from bitstrings to the phases that the oracle should impart
             on them. If the oracle should "look" for a bitstring, it should have a ``-1``, otherwise
             it should have a ``1``.
-        :type bitstring_map: Dict[String, Int]
         :return: Returns the bitstring resulting from measurement after Grover's Algorithm.
-        :rtype: str
         """
 
         self._init_attr(bitstring_map)
-        sampled_bitstring = cxn.run_and_measure(self.grover_circuit, self.qubits)[0]
+
+        ro = self.grover_circuit.declare('ro', 'BIT', len(self.qubits))
+        self.grover_circuit += [MEASURE(qubit, ro[idx]) for idx, qubit in enumerate(self.qubits)]
+        self.grover_circuit.wrap_in_numshots_loop(1)
+        executable = qc.compiler.native_quil_to_executable(self.grover_circuit)
+        sampled_bitstring = qc.run(executable)
+
         return "".join([str(bit) for bit in sampled_bitstring])
 
     @staticmethod
-    def oracle_grover(oracle, qubits, num_iter=None):
-        r"""Implementation of Grover's Algorithm for a given oracle.
+    def oracle_grover(oracle: Program, qubits: List[int], num_iter: int = None) -> Program:
+        """
+        Implementation of Grover's Algorithm for a given oracle.
 
-        :param Program oracle: An oracle defined as a Program. It should send :math:`\ket{x}`
+        :param oracle: An oracle defined as a Program. It should send :math:`\ket{x}`
             to :math:`(-1)^{f(x)}\ket{x}`, where the range of f is {0, 1}.
         :param qubits: List of qubits for Grover's Algorithm.
-        :type qubits: list[int or Qubit]
-        :param int num_iter: The number of iterations to repeat the algorithm for.
-                             The default is the integer closest to :math:`\frac{\pi}{4}\sqrt{N}`,
-                             where :math:`N` is the size of the domain.
+        :param num_iter: The number of iterations to repeat the algorithm for.
+                         The default is the integer closest to :math:`\frac{\pi}{4}\sqrt{N}`,
+                         where :math:`N` is the size of the domain.
         :return: A program corresponding to the desired instance of Grover's Algorithm.
-        :rtype: Program
         """
         if num_iter is None:
             num_iter = int(round(np.pi * 2 ** (len(qubits) / 2.0 - 2.0)))
-        uniform_superimposer = pq.Program().inst([H(qubit) for qubit in qubits])
+        uniform_superimposer = Program().inst([H(qubit) for qubit in qubits])
         amp_prog = amplification_circuit(uniform_superimposer, oracle, qubits, num_iter)
         return amp_prog

--- a/grove/amplification/grover.py
+++ b/grove/amplification/grover.py
@@ -106,7 +106,7 @@ class Grover(object):
         executable = qc.compiler.native_quil_to_executable(self.grover_circuit)
         sampled_bitstring = qc.run(executable)
 
-        return "".join([str(bit) for bit in sampled_bitstring])
+        return "".join([str(bit) for bit in sampled_bitstring[0]])
 
     @staticmethod
     def oracle_grover(oracle: Program, qubits: List[int], num_iter: int = None) -> Program:

--- a/grove/amplification/oracles.py
+++ b/grove/amplification/oracles.py
@@ -13,18 +13,21 @@
 #    See the License for the specific language governing permissions and
 #    limitations under the License.
 ##############################################################################
-"""Module containing implementations of oracle Programs.
 """
+Module containing implementations of oracle Programs.
+"""
+from typing import List
 
 import numpy as np
-import pyquil.quil as pq
-from pyquil.gates import X, Z, CNOT
+from pyquil import Program
+from pyquil.gates import X, Z
 
 from grove.utils.utility_programs import ControlledProgramBuilder
 
 
-def basis_selector_oracle(qubits, bitstring):
-    """Defines an oracle that selects the ith element of the computational basis.
+def basis_selector_oracle(qubits: List[int], bitstring: str) -> Program:
+    """
+    Defines an oracle that selects the ith element of the computational basis.
 
     Flips the sign of the state :math:`\\vert x\\rangle>`
     if and only if x==bitstring and does nothing otherwise.
@@ -33,18 +36,17 @@ def basis_selector_oracle(qubits, bitstring):
      most significant qubit to least significant qubit.
     :param bitstring: The desired bitstring, given as a string of ones and zeros. e.g. "101"
     :return: A program representing this oracle.
-    :rtype: Program
     """
     if len(qubits) != len(bitstring):
         raise ValueError("The bitstring should be the same length as the number of qubits.")
-    oracle_prog = pq.Program()
+    oracle_prog = Program()
 
     # In the case of one qubit, we just want to flip the phase of state relative to the other.
     if len(bitstring) == 1:
         oracle_prog.inst(Z(qubits[0]))
         return oracle_prog
     else:
-        bitflip_prog = pq.Program()
+        bitflip_prog = Program()
         for i, qubit in enumerate(qubits):
             if bitstring[i] == '0':
                 bitflip_prog.inst(X(qubit))

--- a/grove/bernstein_vazirani/bernstein_vazirani.py
+++ b/grove/bernstein_vazirani/bernstein_vazirani.py
@@ -183,8 +183,7 @@ class BernsteinVazirani(object):
         full_circuit += self.bv_circuit
         full_circuit += [MEASURE(qubit, ro) for qubit, ro in zip(self.computational_qubits,
                                                                  full_ro)]
-        full_circuit.wrap_in_numshots_loop(1)
-        full_executable = qc.compiler.native_quil_to_executable(full_circuit)
+        full_executable = qc.compile(full_circuit)
         full_results = qc.run(full_executable)
         bv_vector = full_results[0][::-1]
 
@@ -193,8 +192,7 @@ class BernsteinVazirani(object):
         ancilla_ro = ancilla_circuit.declare('ro', 'BIT', len(self.computational_qubits) + 1)
         ancilla_circuit += self.bv_circuit
         ancilla_circuit += [MEASURE(self.ancilla, ancilla_ro[self.ancilla])]
-        ancilla_circuit.wrap_in_numshots_loop(1)
-        ancilla_executable = qc.compiler.native_quil_to_executable(ancilla_circuit)
+        ancilla_executable = qc.compile(ancilla_circuit)
         ancilla_results = qc.run(ancilla_executable)
         bv_bias = ancilla_results[0][0]
 

--- a/grove/bernstein_vazirani/bernstein_vazirani.py
+++ b/grove/bernstein_vazirani/bernstein_vazirani.py
@@ -181,7 +181,8 @@ class BernsteinVazirani(object):
         full_circuit = Program()
         full_ro = full_circuit.declare('ro', 'BIT', len(self.computational_qubits) + 1)
         full_circuit += self.bv_circuit
-        full_circuit += [MEASURE(i, full_ro[i]) for i in range(len(self.computational_qubits))]
+        full_circuit += [MEASURE(qubit, ro) for qubit, ro in zip(self.computational_qubits,
+                                                                 full_ro)]
         full_circuit.wrap_in_numshots_loop(1)
         full_executable = qc.compiler.native_quil_to_executable(full_circuit)
         full_results = qc.run(full_executable)

--- a/grove/bernstein_vazirani/utils.py
+++ b/grove/bernstein_vazirani/utils.py
@@ -3,28 +3,26 @@ from operator import xor
 PADDED_BINARY_BIT_STRING = "{0:0{1:0d}b}"
 
 
-def bitwise_dot_product(bs0, bs1):
+def bitwise_dot_product(bs0: str, bs1: str) -> str:
     """
     A helper to calculate the bitwise dot-product between two string representing bit-vectors
 
-    :param String bs0: String of 0's and 1's representing a number in binary representations
-    :param String bs1: String of 0's and 1's representing a number in binary representations
+    :param bs0: String of 0's and 1's representing a number in binary representations
+    :param bs1: String of 0's and 1's representing a number in binary representations
     :return: 0 or 1 as a string corresponding to the dot-product value
-    :rtype: String
     """
     if len(bs0) != len(bs1):
         raise ValueError("Bit strings are not of equal length")
     return str(sum([int(bs0[i]) * int(bs1[i]) for i in range(len(bs0))]) % 2)
 
 
-def bitwise_xor(bs0, bs1):
+def bitwise_xor(bs0: str, bs1: str) -> str:
     """
     A helper to calculate the bitwise XOR of two bit string
 
-    :param String bs0: String of 0's and 1's representing a number in binary representations
-    :param String bs1: String of 0's and 1's representing a number in binary representations
+    :param bs0: String of 0's and 1's representing a number in binary representations
+    :param bs1: String of 0's and 1's representing a number in binary representations
     :return: String of 0's and 1's representing the XOR between bs0 and bs1
-    :rtype: String
     """
     if len(bs0) != len(bs1):
         raise ValueError("Bit strings are not of equal length")

--- a/grove/deutsch_jozsa/deutsch_jozsa.py
+++ b/grove/deutsch_jozsa/deutsch_jozsa.py
@@ -61,8 +61,7 @@ class DeutschJosza(object):
         dj_ro = prog.declare('ro', 'BIT', len(self.computational_qubits))
         prog += self.deutsch_jozsa_circuit
         prog += [MEASURE(qubit, ro) for qubit, ro in zip(self.computational_qubits, dj_ro)]
-        prog.wrap_in_numshots_loop(1)
-        executable = qc.compiler.native_quil_to_executable(prog)
+        executable = qc.compile(prog)
         returned_bitstring = qc.run(executable)
         # We are only running a single shot, so we are only interested in the first element.
         bitstring = np.array(returned_bitstring, dtype=int)

--- a/grove/qft/fourier.py
+++ b/grove/qft/fourier.py
@@ -13,33 +13,33 @@
 #    See the License for the specific language governing permissions and
 #    limitations under the License.
 ##############################################################################
-
-import pyquil.quil as pq
-from pyquil.gates import SWAP, H, CPHASE
 import math
+from typing import List
+
+from pyquil import Program
+from pyquil.gates import SWAP, H, CPHASE
 
 
-def bit_reversal(qubits):
+def bit_reversal(qubits: List[int]) -> Program:
     """
     Generate a circuit to do bit reversal.
 
     :param qubits: Qubits to do bit reversal with.
     :return: A program to do bit reversal.
     """
-    p = pq.Program()
+    p = Program()
     n = len(qubits)
     for i in range(int(n / 2)):
         p.inst(SWAP(qubits[i], qubits[-i - 1]))
     return p
 
 
-def _core_qft(qubits, coeff):
+def _core_qft(qubits: List[int], coeff: int) -> Program:
     """
     Generates the core program to perform the quantum Fourier transform
     
     :param qubits: A list of qubit indexes.
-    :param coeff: A modifier for the angle used in rotations (-1 for inverse 
-                  QFT, 1 for QFT)
+    :param coeff: A modifier for the angle used in rotations (-1 for inverse QFT, 1 for QFT)
     :return: A Quil program to compute the core (inverse) QFT of the qubits.
     """
     
@@ -57,32 +57,29 @@ def _core_qft(qubits, coeff):
         return _core_qft(qs, coeff) + list(reversed(cR)) + [H(q)]
 
 
-def qft(qubits):
+def qft(qubits: List[int]) -> Program:
     """
-    Generate a program to compute the quantum Fourier transform on
-    a set of qubits.
+    Generate a program to compute the quantum Fourier transform on a set of qubits.
 
     :param qubits: A list of qubit indexes.
     :return: A Quil program to compute the Fourier transform of the qubits.
     """
 
-    p = pq.Program().inst(_core_qft(qubits, 1))
+    p = Program().inst(_core_qft(qubits, 1))
     return p + bit_reversal(qubits)
 
 
-def inverse_qft(qubits):
+def inverse_qft(qubits: List[int]) -> Program:
     """
-    Generate a program to compute the inverse quantum Fourier transform on
-    a set of qubits.
+    Generate a program to compute the inverse quantum Fourier transform on a set of qubits.
 
     :param qubits: A list of qubit indexes.
-    :return: A Quil program to compute the inverse Fourier transform of the 
-             qubits.
+    :return: A Quil program to compute the inverse Fourier transform of the qubits.
     """
     
-    qft_result = pq.Program().inst(_core_qft(qubits, -1))
+    qft_result = Program().inst(_core_qft(qubits, -1))
     qft_result += bit_reversal(qubits)
-    inverse_qft = pq.Program()
+    inverse_qft = Program()
     while len(qft_result) > 0:
         new_inst = qft_result.pop()
         inverse_qft.inst(new_inst)

--- a/grove/simon/simon.py
+++ b/grove/simon/simon.py
@@ -257,8 +257,7 @@ class Simon(object):
             simon_ro = prog.declare('ro', 'BIT', len(self.computational_qubits))
             prog += self.simon_circuit
             prog += [MEASURE(qubit, ro) for qubit, ro in zip(self.computational_qubits, simon_ro)]
-            prog.wrap_in_numshots_loop(1)
-            executable = qc.compiler.native_quil_to_executable(prog)
+            executable = qc.compile(prog)
             sampled_bit_string = np.array(qc.run(executable)[0], dtype=int)
 
             self._add_to_dict_of_indep_bit_vectors(sampled_bit_string)

--- a/grove/simon/utils.py
+++ b/grove/simon/utils.py
@@ -1,16 +1,17 @@
-import numpy as np
 from operator import xor
+from typing import List
+
+import numpy as np
 
 PADDED_BINARY_BIT_STRING = "{0:0{1:0d}b}"
 
 
-def is_unitary(matrix):
+def is_unitary(matrix: np.ndarray) -> bool:
     """
     A helper function that checks if a matrix is unitary.
 
-    :param 2darray matrix: a matrix to test unitarity of
+    :param matrix: a matrix to test unitarity of
     :return: true if and only if matrix is unitary
-    :rtype: bool
     """
     rows, cols = matrix.shape
     if rows != cols:
@@ -18,27 +19,24 @@ def is_unitary(matrix):
     return np.allclose(np.eye(rows), matrix.dot(matrix.T.conj()))
 
 
-def most_significant_bit(lst):
+def most_significant_bit(lst: np.ndarray) -> int:
     """
-    A helper function that finds the position of
-    the most significant bit in a 1darray of 1s and 0s,
+    A helper function that finds the position of the most significant bit in a 1darray of 1s and 0s,
     i.e. the first position where a 1 appears, reading left to right.
 
-    :param 1darray lst: a 1darray of 0s and 1s with at least one 1
+    :param lst: a 1d array of 0s and 1s with at least one 1
     :return: the first position in lst that a 1 appears
-    :rtype: int
     """
     return np.argwhere(np.asarray(lst) == 1)[0][0]
 
 
-def bitwise_xor(bs0, bs1):
+def bitwise_xor(bs0: str, bs1: str) -> str:
     """
     A helper to calculate the bitwise XOR of two bit string
 
     :param bs0: String of 0's and 1's representing a number in binary representations
     :param bs1: String of 0's and 1's representing a number in binary representations
     :return: String of 0's and 1's representing the XOR between bs0 and bs1
-    :rtype: str
     """
     if len(bs0) != len(bs1):
         raise ValueError("Bit strings are not of equal length")
@@ -46,19 +44,18 @@ def bitwise_xor(bs0, bs1):
     return PADDED_BINARY_BIT_STRING.format(xor(int(bs0, 2), int(bs1, 2)), n_bits)
 
 
-def binary_back_substitute(W, s):
+def binary_back_substitute(W: np.ndarray, s: np.ndarray) -> np.ndarray:
     """
     Perform back substitution on a binary system of equations, i.e. it performs Gauss elimination
     over the field :math:`GF(2)`. It finds an :math:`\\mathbf{x}` such that
     :math:`\\mathbf{\\mathit{W}}\\mathbf{x}=\\mathbf{s}`, where all arithmetic is taken bitwise
     and modulo 2.
 
-    :param 2darray W: A square :math:`n\\times n` matrix of 0s and 1s,
+    :param W: A square :math:`n\\times n` matrix of 0s and 1s,
               in row-echelon (upper-triangle) form
-    :param 1darray s: An :math:`n\\times 1` vector of 0s and 1s
+    :param s: An :math:`n\\times 1` vector of 0s and 1s
     :return: The :math:`n\\times 1` vector of 0s and 1s that solves the above
              system of equations.
-    :rtype: 1darray
     """
     # iterate backwards, starting from second to last row for back-substitution
     m = np.copy(s)

--- a/grove/tests/amplification/test_grover.py
+++ b/grove/tests/amplification/test_grover.py
@@ -88,10 +88,10 @@ def test_optimal_grover(x_oracle):
 def test_find_bitstring():
     bitstring_map = {"0": 1, "1": -1}
     builder = Grover()
-    with patch("pyquil.api.JobConnection") as qvm:
+    with patch("pyquil.api.QuantumComputer") as qc:
         expected_bitstring = [0, 1]
-        qvm.run_and_measure.return_value = ["".join([str(bit) for bit in expected_bitstring])]
-    returned_bitstring = builder.find_bitstring(qvm, bitstring_map)
+        qc.run.return_value = ["".join([str(bit) for bit in expected_bitstring])]
+    returned_bitstring = builder.find_bitstring(qc, bitstring_map)
     prog = builder.grover_circuit
     # Make sure it only defines the ORACLE gate and the DIFFUSION gate.
     assert len(prog.defined_gates) == 2

--- a/grove/tests/bernstein_vazirani/test_bernstein_vazirani.py
+++ b/grove/tests/bernstein_vazirani/test_bernstein_vazirani.py
@@ -34,15 +34,15 @@ def test_bv_class_with_bitmap():
         '111': '1'
     }
 
-    with patch("pyquil.api.QVMConnection") as qvm:
+    with patch("pyquil.api.QuantumComputer") as qc:
         # Need to mock multiple returns as an iterable
-        qvm.run_and_measure.side_effect = [
+        qc.run.side_effect = [
             ([0, 1, 1], ),
             ([1], )
         ]
 
     bv = BernsteinVazirani()
-    bv.run(qvm, bit_map).check_solution()
+    bv.run(qc, bit_map).check_solution()
     bv_a, bv_b = bv.solution
     assert bv_a == '110'
     assert bv_b == '1'
@@ -54,15 +54,15 @@ def test_bv_class_with_check_results():
 
     bit_map = create_bv_bitmap(a, b)
 
-    with patch("pyquil.api.QVMConnection") as qvm:
+    with patch("pyquil.api.QuantumComputer") as qc:
         # Need to mock multiple returns as an iterable
-        qvm.run_and_measure.side_effect = [
+        qc.run.side_effect = [
             ([1, 1, 0, 1], ),
             ([0], )
         ]
 
     bv = BernsteinVazirani()
-    bv.run(qvm, bit_map).check_solution()
+    bv.run(qc, bit_map).check_solution()
     bv_a, bv_b = bv.solution
     assert bv_a == a
     assert bv_b == b
@@ -74,15 +74,15 @@ def test_bv_class_with_return_solution():
 
     bit_map = create_bv_bitmap(a, b)
 
-    with patch("pyquil.api.QVMConnection") as qvm:
+    with patch("pyquil.api.QuantumComputer") as qc:
         # Need to mock multiple returns as an iterable
-        qvm.run_and_measure.side_effect = [
+        qc.run.side_effect = [
             ([1, 1, 0, 1], ),
             ([0], )
         ]
 
     bv = BernsteinVazirani()
-    bv_a, bv_b = bv.run(qvm, bit_map).get_solution()
+    bv_a, bv_b = bv.run(qc, bit_map).get_solution()
     assert bv_a == a
     assert bv_b == b
 

--- a/grove/tests/circuit_primitives/test_swap.py
+++ b/grove/tests/circuit_primitives/test_swap.py
@@ -56,9 +56,11 @@ def test_run_swap():
     expected_bitstring = [1, 1, 1, 0, 0, 0, 0, 0, 0]
     prog_a = Program().inst(H(0))
     prog_b = Program().inst(H(1))
-    with patch("pyquil.api.QVMConnection") as qvm:
-        qvm.run.return_value = expected_bitstring
-        test_overlap = run_swap_test(prog_a, prog_b, 5, qvm)
+    with patch("pyquil.api.QuantumComputer") as qc:
+        qc.run.return_value = expected_bitstring
+        test_overlap = run_swap_test(prog_a, prog_b,
+                                     number_of_measurements=5,
+                                     quantum_resource=qc)
 
         assert np.isclose(np.sqrt(1 - 2 * np.mean(expected_bitstring)),
                           test_overlap)
@@ -66,8 +68,10 @@ def test_run_swap():
     expected_bitstring = [1, 1, 1, 0, 1]
     prog_a = Program().inst(H(0))
     prog_b = Program().inst(H(1))
-    with patch("pyquil.api.QVMConnection") as qvm:
-        qvm.run.return_value = expected_bitstring
+    with patch("pyquil.api.QuantumComputer") as qc:
+        qc.run.return_value = expected_bitstring
         with pytest.raises(ValueError):
-            test_overlap = run_swap_test(prog_a, prog_b, 5, qvm)
+            test_overlap = run_swap_test(prog_a, prog_b,
+                                         number_of_measurements=5,
+                                         quantum_resource=qc)
 

--- a/grove/tests/deutsch_jozsa/test_deutsch_jozsa.py
+++ b/grove/tests/deutsch_jozsa/test_deutsch_jozsa.py
@@ -1,8 +1,7 @@
-from mock import patch, Mock
-import pytest
-
 import numpy as np
-import pyquil.quil as pq
+import pytest
+from mock import patch
+from pyquil import Program
 from pyquil.gates import X, H, CNOT
 
 from grove.deutsch_jozsa.deutsch_jozsa import DeutschJosza, ORACLE_GATE_NAME
@@ -15,20 +14,20 @@ from grove.deutsch_jozsa.deutsch_jozsa import DeutschJosza, ORACLE_GATE_NAME
                           np.asarray([0, 0], dtype=int))])
 def test_deutsch_jozsa_one_qubit_exact_zeros(bitmap, expected_bitstring):
     dj = DeutschJosza()
-    with patch("pyquil.api.QVMConnection") as qvm:
-        qvm.run_and_measure.return_value = expected_bitstring
-        is_constant = dj.is_constant(qvm, bitmap)
+    with patch("pyquil.api.QuantumComputer") as qc:
+        qc.run.return_value = expected_bitstring
+        is_constant = dj.is_constant(qc, bitmap)
     assert is_constant
 
 
 def test_deutsch_jozsa_one_qubit_balanced():
     balanced_one_qubit_bitmap = {"0": "0", "1": "1"}
     dj = DeutschJosza()
-    with patch("pyquil.api.QVMConnection") as qvm:
+    with patch("pyquil.api.QuantumComputer") as qc:
         # Should just be not the zero vector
         expected_bitstring = np.asarray([0, 1], dtype=int)
-        qvm.run_and_measure.return_value = expected_bitstring
-        is_constant = dj.is_constant(qvm, balanced_one_qubit_bitmap)
+        qc.run.return_value = expected_bitstring
+        is_constant = dj.is_constant(qc, balanced_one_qubit_bitmap)
     assert not is_constant
 
 
@@ -36,20 +35,20 @@ def test_deutsch_jozsa_two_qubit_neither():
     exact_two_qubit_bitmap = {"00": "0", "01": "0", "10": "1", "11": "00"}
     dj = DeutschJosza()
     with pytest.raises(ValueError):
-        with patch("pyquil.api.QVMConnection") as qvm:
-            _ = dj.is_constant(qvm, exact_two_qubit_bitmap)
+        with patch("pyquil.api.QuantumComputer") as qc:
+            _ = dj.is_constant(qc, exact_two_qubit_bitmap)
 
 
 def test_one_qubit_exact_zeros_circuit():
     exact_one_qubit_bitmap = {"0": "0", "1": "1"}
     dj = DeutschJosza()
-    with patch("pyquil.api.QVMConnection") as qvm:
+    with patch("pyquil.api.QuantumComputer") as qc:
         # Should just be not the zero vector
         expected_bitstring = np.asarray([0, 1], dtype=int)
-        qvm.run_and_measure.return_value = expected_bitstring
-        _ = dj.is_constant(qvm, exact_one_qubit_bitmap)
+        qc.run.return_value = expected_bitstring
+        _ = dj.is_constant(qc, exact_one_qubit_bitmap)
     # Ordering doesn't matter, so we pop instructions from a set
-    expected_prog = pq.Program()
+    expected_prog = Program()
 
     # We've defined the oracle and its dagger.
     dj_circuit = dj.deutsch_jozsa_circuit

--- a/grove/tests/qft/test_qft.py
+++ b/grove/tests/qft/test_qft.py
@@ -13,30 +13,28 @@
 #    See the License for the specific language governing permissions and
 #    limitations under the License.
 ##############################################################################
+from pyquil import Program
+from pyquil.gates import H, X, CPHASE, SWAP
 
-from pyquil.gates import *
 from grove.qft.fourier import inverse_qft
-import pyquil.quil as pq
 
 
 def test_simple_inverse_qft():
-    
-    trial_prog = pq.Program()
+    trial_prog = Program()
     trial_prog.inst(X(0))
     trial_prog = trial_prog + inverse_qft([0])
     
-    result_prog = pq.Program().inst([X(0), H(0)])
+    result_prog = Program().inst([X(0), H(0)])
     
     assert trial_prog == result_prog
 
 
 def test_multi_qubit_qft():
-    
-    trial_prog = pq.Program()
+    trial_prog = Program()
     trial_prog.inst(X(0), X(1), X(2))
     trial_prog = trial_prog + inverse_qft([0, 1, 2])
     
-    result_prog = pq.Program().inst([X(0), X(1), X(2),
+    result_prog = Program().inst([X(0), X(1), X(2),
                                      SWAP(0, 2), H(0),
                                      CPHASE(-1.5707963267948966, 0, 1),
                                      CPHASE(-0.7853981633974483, 0, 2),

--- a/grove/tests/simon/test_simon.py
+++ b/grove/tests/simon/test_simon.py
@@ -4,7 +4,7 @@ from os.path import abspath, dirname
 
 import numpy as np
 from mock import patch
-from pyquil.quil import Program
+from pyquil import Program
 
 from grove.simon.simon import Simon, create_1to1_bitmap, create_valid_2to1_bitmap
 
@@ -33,9 +33,9 @@ def test_simon_class():
     https://cs.uwaterloo.ca/~watrous/CPSC519/LectureNotes/06.pdf"""
     simon_algo = Simon()
 
-    with patch("pyquil.api.QVMConnection") as qvm:
+    with patch("pyquil.api.QuantumComputer") as qc:
         # Need to mock multiple returns as an iterable
-        qvm.run_and_measure.side_effect = [
+        qc.run.side_effect = [
             (np.asarray([1, 1, 1], dtype=int), ),
             (np.asarray([1, 1, 1], dtype=int), ),
             (np.asarray([1, 0, 0], dtype=int), ),
@@ -56,7 +56,7 @@ def test_simon_class():
         '111': '010'
     }
 
-    mask = simon_algo.find_mask(qvm, bit_string_mapping)
+    mask = simon_algo.find_mask(qc, bit_string_mapping)
 
     assert simon_algo.n_qubits == 3
     assert simon_algo.n_ancillas == 3


### PR DESCRIPTION
The `alpha` modules have already been migrated and merged into master, and @mpharrigan and I have decided that the `pyvqe`, `pyqaoa`, and `ising` modules will be dealt with in a separate PR because they're heavily interdependent, so this PR migrates the remaining grove modules. This resolves #186. 